### PR TITLE
Adds script to populate Elasticsearch index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,28 @@
 {
-  "requires": true,
+  "name": "crime-data",
+  "version": "0.1.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
+    "agentkeepalive": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-2.2.0.tgz",
+      "integrity": "sha1-xdG9SxKQCPEWPyNvhuX66iAm4u8="
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
     "assertion-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
-      "dev": true
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -34,7 +50,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.1.tgz",
       "integrity": "sha1-ZuISeebzxkFf+CMYeCJ5AOIXGzk=",
-      "dev": true,
       "requires": {
         "assertion-error": "1.0.2",
         "check-error": "1.0.2",
@@ -44,11 +59,29 @@
         "type-detect": "4.0.3"
       }
     },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-      "dev": true
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
     "commander": {
       "version": "2.9.0",
@@ -78,7 +111,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
       "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
-      "dev": true,
       "requires": {
         "type-detect": "3.0.0"
       },
@@ -86,8 +118,7 @@
         "type-detect": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-3.0.0.tgz",
-          "integrity": "sha1-RtDMhVOrt7E6NSsNbeov1Y8tm1U=",
-          "dev": true
+          "integrity": "sha1-RtDMhVOrt7E6NSsNbeov1Y8tm1U="
         }
       }
     },
@@ -97,11 +128,30 @@
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
+    "elasticsearch": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-13.3.1.tgz",
+      "integrity": "sha1-xTCuqa+xfqkcPQpW8fERukm8kjk=",
+      "requires": {
+        "agentkeepalive": "2.2.0",
+        "chalk": "1.1.3",
+        "lodash": "2.4.2",
+        "lodash.get": "4.4.2",
+        "lodash.isempty": "4.4.0",
+        "lodash.trimend": "4.5.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+        }
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -112,8 +162,7 @@
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
-      "dev": true
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
     },
     "glob": {
       "version": "7.1.1",
@@ -140,6 +189,14 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-flag": {
       "version": "1.0.0",
@@ -168,6 +225,11 @@
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -214,6 +276,11 @@
         "lodash._isiterateecall": "3.0.9"
       }
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -226,6 +293,11 @@
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
+    },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
@@ -236,6 +308,11 @@
         "lodash.isarguments": "3.1.0",
         "lodash.isarray": "3.0.4"
       }
+    },
+    "lodash.trimend": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
+      "integrity": "sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -304,8 +381,15 @@
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-      "dev": true
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "supports-color": {
       "version": "3.1.2",
@@ -319,8 +403,7 @@
     "type-detect": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
-      "dev": true
+      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo="
     },
     "wrappy": {
       "version": "1.0.2",
@@ -328,6 +411,5 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     }
-  },
-  "version": "0.1.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "test": "test"
   },
   "dependencies": {
-    "chai": "^4.1.1"
+    "chai": "^4.1.1",
+    "elasticsearch": "^13.3.1",
+    "lodash": "^4.17.4"
   },
   "devDependencies": {
     "mocha": "^3.5.0"

--- a/scripts/data_indexer.js
+++ b/scripts/data_indexer.js
@@ -1,0 +1,104 @@
+/*
+
+Boston Crime Data ES bulk indexer
+
+Usage: node data_indexer.js /path/to/stats_2012-2015.json /path/to/stats_2015-present.json
+
+The stats for 2012-2015 are here - https://data.cityofboston.gov/Public-Safety/Crime-Incident-Reports-July-2012-August-2015-Sourc/7cdf-6fgx
+The stats for 2015-present are here - https://data.cityofboston.gov/Public-Safety/Crime-Incident-Reports-August-2015-To-Date-Source-/fqn4-4qap
+
+Download the JSON files for each dataset. Each set has different fields and data, but the shared
+(and most interesting) stuff is indexed here.
+
+*/
+
+const fs = require('fs');
+const elasticsearch = require('elasticsearch');
+const _ = require('lodash');
+
+const DATA_2012_TO_2015 = process.argv[2];
+const DATA_2015_TO_PRESENT = process.argv[3];
+const INDEX_NAME = 'crime_data';
+const INDEX_OBJECT = { index: { _index: INDEX_NAME, _type: 'report' } };
+const BULK_BATCH_SIZE = 20000;
+const DEFAULT_REQUEST_TIMEOUT = 300000;
+
+let client = new elasticsearch.Client({
+  host: 'localhost:9200',
+  log: 'trace'
+});
+
+function oldRowProcessor(row) {
+  return {
+    offenseDescription: row[10],
+    offenseCode: row[11],
+    reportingDistrict: row[12],
+    reportingArea: row[13],
+    shooting: row[16],
+    occurredAt: row[14],
+    weekday: row[21],
+    streetName: row[25],
+    latitude: row[27][1],
+    longitude: row[27][2]
+  };
+};
+
+function newRowProcessor(row) {
+  return {
+    offenseDescription: row[11],
+    offenseCode: row[9],
+    reportingDistrict: row[12],
+    reportingArea: row[13],
+    shooting: row[14],
+    occurredAt: row[15],
+    weekday: row[19],
+    streetName: row[21],
+    latitude: row[22],
+    longitude: row[23]
+  };
+};
+
+function buildRequestBody(rows, rowProcessor) {
+  let body = [];
+
+  rows.forEach((row) => {
+    body.push(INDEX_OBJECT);
+    body.push(rowProcessor(row));
+  });
+
+  return body;
+};
+
+function bulkIndex(rows, rowProcessor) {
+  client.bulk({
+    requestTimeout: DEFAULT_REQUEST_TIMEOUT,
+    body: buildRequestBody(rows, rowProcessor)
+  }, (err, response) => {
+    if (err) throw err;
+    console.log(response);
+  });
+};
+
+function processData(rowProcessor) {
+  return (err, data) => {
+    if (err) throw err;
+
+    let allRows = JSON.parse(data).data;
+
+    _.chunk(allRows, BULK_BATCH_SIZE).forEach((rows) => {
+      bulkIndex(rows, rowProcessor);
+    });
+  };
+};
+
+client.indices.delete({
+  index: INDEX_NAME,
+  ignore: [404]
+}).then((body) => {
+  console.log(body);
+}, (error) => {
+  console.log(error);
+});
+
+fs.readFile(DATA_2012_TO_2015, processData(oldRowProcessor));
+fs.readFile(DATA_2015_TO_PRESENT, processData(newRowProcessor));


### PR DESCRIPTION
This adds a script to add crime data records to an Elasticsearch index.
It uses the bulk-indexing feature, and the batch size has been tuned to
prevent too many concurrent requests during the indexing process.

The documents used for the data are JSON versions of Boston city crime
report data - `https://data.cityofboston.gov/browse?tags=crime`.

Lodash and Elasticsearch packages were also added.